### PR TITLE
feat: Add TypeScript Weather & Geocoding MCP Server

### DIFF
--- a/openweather-mcp-server/.env.example
+++ b/openweather-mcp-server/.env.example
@@ -1,0 +1,2 @@
+# OpenWeatherMap API Key - Get yours from https://openweathermap.org/appid
+OPENWEATHERMAP_API_KEY=YOUR_API_KEY_GOES_HERE 

--- a/openweather-mcp-server/.gitignore
+++ b/openweather-mcp-server/.gitignore
@@ -1,0 +1,19 @@
+# Node modules
+node_modules/
+
+# Compiled TypeScript
+dist/
+
+# Environment variables
+.env*
+!.env.example
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+
+# OS generated files
+.DS_Store
+Thumbs.db 

--- a/openweather-mcp-server/Dockerfile
+++ b/openweather-mcp-server/Dockerfile
@@ -1,0 +1,41 @@
+# Stage 1: Build the application
+FROM node:18-alpine AS builder
+
+WORKDIR /app
+
+# Copy package files
+COPY package.json package-lock.json* ./
+
+# Install all dependencies (including devDependencies for build)
+RUN npm ci
+
+# Copy source code and config files
+COPY tsconfig.json ./
+COPY src ./src
+
+# Compile TypeScript to JavaScript
+RUN npm run build
+
+# Stage 2: Create the final production image
+FROM node:18-alpine
+
+WORKDIR /app
+
+# Copy package files again
+COPY package.json package-lock.json* ./
+
+# Install ONLY production dependencies
+RUN npm ci --omit=dev
+
+# Copy compiled code from the builder stage
+COPY --from=builder /app/dist ./dist
+
+# Copy .env file (consider injecting secrets at runtime instead for production)
+# COPY .env ./
+
+# Expose the port the app runs on (as defined in src/server.ts or .env)
+# Defaulting to 8000 if not set in .env
+EXPOSE 8000
+
+# Command to run the compiled JavaScript application
+CMD ["node", "dist/server.js"] 

--- a/openweather-mcp-server/README.md
+++ b/openweather-mcp-server/README.md
@@ -1,0 +1,121 @@
+# TypeScript MCP Server (Weather & Geocoding)
+
+This project provides a Model Context Protocol (MCP) server built with TypeScript. It allows MCP clients (like AI assistants or other applications) to fetch current weather data and geocoding information using public APIs.
+
+## Prerequisites
+
+*   Node.js (v18 or later recommended)
+*   npm (usually included with Node.js)
+*   An [OpenWeatherMap API Key](https://openweathermap.org/appid)
+
+## Running Locally
+
+1.  **Clone the repository:**
+    ```bash
+    git clone <repository-url>
+    cd <repository-directory>
+    ```
+2.  **Install dependencies:**
+    ```bash
+    npm install
+    ```
+3.  **Set up API Key:**
+    *   Copy the example environment file: `cp .env.example .env`
+    *   Edit the `.env` file and add your OpenWeatherMap API key:
+      ```dotenv
+      OPENWEATHERMAP_API_KEY=your_actual_key_here
+      ```
+4.  **Run the server:**
+    ```bash
+    npm run dev
+    ```
+    The server will start using `ts-node` and listen for connections on `http://localhost:8000`. It uses Server-Sent Events (SSE) for communication.
+
+## Testing Locally (Easy Method)
+
+The easiest way to test the running server without writing code is using the included HTML test page:
+
+1.  Ensure the server is running locally (`npm run dev`).
+2.  Open the `index.html` file (located in the project root) directly in your web browser.
+3.  In the "Server Base URL" field, ensure it says `http://localhost:8000`.
+4.  Click the **"Connect SSE"** button. The status should change to "Connected & Ready".
+5.  **To test Weather:**
+    *   Tool Name: `get_current_weather`
+    *   Tool Arguments (JSON): `{ "location": "London, UK" }` (or another city/country)
+    *   Click **"Send tools/call Request"**.
+6.  **To test Geocoding:**
+    *   Tool Name: `find_location_info`
+    *   Tool Arguments (JSON): `{ "query": "Eiffel Tower" }` (or another place name)
+    *   Click **"Send tools/call Request"**.
+7.  Results from the server will appear in the "Logs / Server Responses" box on the page.
+
+## Available Tools
+
+The server currently exposes the following tools for MCP clients:
+
+1.  **`get_current_weather`**
+    *   **Description:** Fetches the current weather conditions for a specified location.
+    *   **Arguments:**
+        *   `location` (string, **required**): The city and state/country (e.g., `"San Francisco, CA"`, `"London, UK"`, `"Boston, US"`).
+        *   `units` (string, *optional*, default: `"metric"`): Units for temperature. Options: `"metric"` (Celsius), `"imperial"` (Fahrenheit), `"standard"` (Kelvin).
+    *   **Example JSON Arguments:** `{ "location": "Tokyo, Japan", "units": "metric" }`
+
+2.  **`find_location_info`**
+    *   **Description:** Finds address details and coordinates for a given place name using OpenStreetMap Nominatim.
+    *   **Arguments:**
+        *   `query` (string, **required**): The place name or address to search for (e.g., `"Eiffel Tower"`, `"Statue of Liberty"`).
+    *   **Example JSON Arguments:** `{ "query": "Golden Gate Bridge" }`
+
+## Example Client Queries
+
+An AI assistant integrated with this server could potentially handle requests like:
+
+*   "What's the current temperature in Berlin using metric units?" (Uses `get_current_weather`)
+*   "Fetch the weather for Oslo, Norway." (Uses `get_current_weather`)
+*   "Where is the Brandenburg Gate located?" (Uses `find_location_info`)
+*   "Get location details for Mount Fuji." (Uses `find_location_info`)
+
+## Deployment Guide (AWS App Runner)
+
+This server is containerized using the included `Dockerfile` and can be deployed to services like AWS App Runner.
+
+1.  **Build the Docker Image:** Ensure Docker is running. Build the image for the correct platform:
+    ```bash
+    docker build --platform linux/amd64 -t your-image-name .
+    ```
+    *(Replace `your-image-name` with a suitable tag like `ts-mcp-server-weather-geo`)*
+2.  **Push Image to ECR:**
+    *   Create a private AWS ECR repository (e.g., `your-image-name`) in your desired region.
+    *   Authenticate Docker with ECR (`aws ecr get-login-password ... | docker login ...`).
+    *   Tag your image with the full ECR URI: `docker tag your-image-name:latest <account_id>.dkr.ecr.<region>.amazonaws.com/your-image-name:latest`.
+    *   Push the image: `docker push <account_id>.dkr.ecr.<region>.amazonaws.com/your-image-name:latest`.
+3.  **Create App Runner Service:**
+    *   In the App Runner console, create a new service.
+    *   Source: Container registry, pointing to your ECR image.
+    *   Deployment: Automatic (recommended). Create a new ECR access role.
+    *   Configure Service:
+        *   Set **Port** to `8000`.
+        *   Add **Environment Variable:** `OPENWEATHERMAP_API_KEY` = `your_actual_key_here`. **Do not hardcode keys!**
+        *   Configure **Health Check:** Use HTTP protocol on path `/health`.
+    *   Create and deploy the service.
+4.  **Test:** Use the provided App Runner URL (HTTPS) with the `index.html` test page or another MCP client.
+
+## Project Structure
+
+*   `src/server.ts`: Main server logic (Express, McpServer, Tools, SSE).
+*   `src/client.ts`: Example testing client (uses SSE).
+*   `index.html`: Browser-based test client (uses SSE).
+*   `Dockerfile`: Builds the production container image.
+*   `package.json` / `package-lock.json`: Node dependencies.
+*   `tsconfig.json`: TypeScript configuration.
+*   `.env.example`: Example environment file.
+*   `.gitignore`: Git ignore configuration.
+
+## Technologies Used
+
+*   Node.js, TypeScript
+*   `@modelcontextprotocol/sdk`
+*   Express.js, SSE
+*   `zod`, `axios`, `dotenv`, `cors`
+*   OpenWeatherMap API, OpenStreetMap Nominatim API
+*   Docker, AWS App Runner, AWS ECR

--- a/openweather-mcp-server/index.html
+++ b/openweather-mcp-server/index.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MCP SSE Test Client</title>
+    <style>
+        body { font-family: sans-serif; line-height: 1.5; padding: 1em; }
+        label, input, textarea, button { display: block; margin-bottom: 0.5em; }
+        input, textarea { width: 90%; max-width: 600px; padding: 0.3em; }
+        textarea { height: 8em; }
+        #logs { height: 300px; width: 90%; max-width: 600px; border: 1px solid #ccc; overflow-y: scroll; background-color: #f8f8f8; padding: 0.5em; white-space: pre-wrap; font-family: monospace; }
+        .error { color: red; }
+        .info { color: blue; }
+        .sent { color: darkmagenta; }
+        .received { color: darkgreen; }
+    </style>
+</head>
+<body>
+
+<h1>MCP SSE Test Client</h1>
+
+<label for="serverUrl">Server Base URL:</label>
+<input type="text" id="serverUrl" value="http://localhost:8000">
+<button id="connectBtn">Connect SSE</button>
+<button id="disconnectBtn" disabled>Disconnect SSE</button>
+<p id="connectionStatus" class="info">Status: Disconnected</p>
+
+<hr>
+
+<div>
+    <label for="toolName">Tool Name:</label>
+    <input type="text" id="toolName" placeholder="e.g., get_current_weather">
+
+    <label for="toolArgs">Tool Arguments (JSON):</label>
+    <textarea id="toolArgs" placeholder='e.g., { "location": "London, UK" }'></textarea>
+
+    <button id="sendToolCallBtn" disabled>Send tools/call Request</button>
+</div>
+
+<hr>
+
+<h2>Logs / Server Responses</h2>
+<div id="logs"></div>
+
+<script>
+    const serverUrlInput = document.getElementById('serverUrl');
+    const connectBtn = document.getElementById('connectBtn');
+    const disconnectBtn = document.getElementById('disconnectBtn');
+    const connectionStatus = document.getElementById('connectionStatus');
+    const toolNameInput = document.getElementById('toolName');
+    const toolArgsInput = document.getElementById('toolArgs');
+    const sendToolCallBtn = document.getElementById('sendToolCallBtn');
+    const logsDiv = document.getElementById('logs');
+
+    let eventSource = null;
+    let messageUrl = null; // URL for sending POST messages
+    let nextRequestId = 1;
+
+    function logMessage(message, type = 'info') {
+        const p = document.createElement('p');
+        p.textContent = `[${new Date().toLocaleTimeString()}] ${message}`;
+        p.classList.add(type);
+        logsDiv.appendChild(p);
+        logsDiv.scrollTop = logsDiv.scrollHeight; // Auto-scroll
+        console.log(message);
+    }
+
+    function connectSSE() {
+        const baseUrl = serverUrlInput.value.trim();
+        if (!baseUrl) {
+            logMessage('Server Base URL cannot be empty.', 'error');
+            return;
+        }
+        const sseUrl = `${baseUrl}/sse`;
+
+        logMessage(`Attempting to connect to SSE endpoint: ${sseUrl}`, 'info');
+        connectionStatus.textContent = 'Status: Connecting...';
+        connectionStatus.className = 'info';
+        connectBtn.disabled = true;
+        disconnectBtn.disabled = false;
+        sendToolCallBtn.disabled = true; // Disable until messageUrl is known
+        messageUrl = null; // Reset messageUrl
+
+        try {
+            eventSource = new EventSource(sseUrl);
+        } catch (e) {
+            logMessage(`Error creating EventSource: ${e.message}`, 'error');
+            connectionStatus.textContent = 'Status: Error';
+            connectionStatus.className = 'error';
+            connectBtn.disabled = false;
+            disconnectBtn.disabled = true;
+            return;
+        }
+
+        eventSource.onopen = () => {
+            logMessage('SSE Connection Opened.', 'info');
+            connectionStatus.textContent = 'Status: Connected, waiting for endpoint...';
+            connectionStatus.className = 'info';
+        };
+
+        eventSource.onerror = (error) => {
+            logMessage(`SSE Error: ${error.type || 'Unknown error'}. ReadyState: ${eventSource.readyState}`, 'error');
+            console.error('SSE Error Event:', error);
+            connectionStatus.textContent = `Status: Error (${error.type || 'Unknown'})`;
+            connectionStatus.className = 'error';
+            connectBtn.disabled = false;
+            disconnectBtn.disabled = true;
+            sendToolCallBtn.disabled = true;
+            eventSource.close(); // Close on error
+        };
+
+        eventSource.addEventListener('endpoint', (event) => {
+            const endpointData = event.data;
+            logMessage(`Received 'endpoint' event: ${endpointData}`, 'received');
+            // Construct the full message URL
+            const url = new URL(baseUrl); // Use base URL to get origin
+            messageUrl = `${url.origin}${endpointData}`;
+            logMessage(`Message URL set to: ${messageUrl}`, 'info');
+            connectionStatus.textContent = 'Status: Connected & Ready';
+            connectionStatus.className = 'received';
+            sendToolCallBtn.disabled = false; // Enable sending tool calls
+        });
+
+        eventSource.onmessage = (event) => {
+            logMessage(`Received message: ${event.data}`, 'received');
+            // Here you would parse event.data (JSON-RPC response) and display nicely
+        };
+    }
+
+    function disconnectSSE() {
+        if (eventSource) {
+            eventSource.close();
+            logMessage('SSE Connection Closed by user.', 'info');
+            connectionStatus.textContent = 'Status: Disconnected';
+            connectionStatus.className = 'info';
+        }
+        connectBtn.disabled = false;
+        disconnectBtn.disabled = true;
+        sendToolCallBtn.disabled = true;
+        messageUrl = null;
+    }
+
+    async function sendToolCall() {
+        const toolName = toolNameInput.value.trim();
+        const argsString = toolArgsInput.value.trim();
+
+        if (!messageUrl) {
+            logMessage('Cannot send: Message URL not yet received from server.', 'error');
+            return;
+        }
+        if (!toolName) {
+            logMessage('Cannot send: Tool Name is empty.', 'error');
+            return;
+        }
+
+        let argsObject = {};
+        if (argsString) {
+            try {
+                argsObject = JSON.parse(argsString);
+            } catch (e) {
+                logMessage(`Cannot send: Tool Arguments are not valid JSON. Error: ${e.message}`, 'error');
+                return;
+            }
+        }
+
+        const requestId = `tool-${nextRequestId++}`;
+        const requestBody = {
+            jsonrpc: "2.0",
+            id: requestId,
+            method: "tools/call",
+            params: {
+                name: toolName,
+                arguments: argsObject
+            }
+        };
+
+        logMessage(`Sending POST to ${messageUrl}: ${JSON.stringify(requestBody, null, 2)}`, 'sent');
+        sendToolCallBtn.disabled = true; // Prevent spamming
+
+        try {
+            const response = await fetch(messageUrl, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
+                body: JSON.stringify(requestBody)
+            });
+
+            logMessage(`POST response status: ${response.status} ${response.statusText}`, response.ok ? 'info' : 'error');
+            if (!response.ok) {
+                const errorText = await response.text();
+                logMessage(`POST response body: ${errorText}`, 'error');
+            }
+            // Response to the tool call will arrive via the SSE connection
+
+        } catch (error) {
+            logMessage(`Error sending POST request: ${error.message}`, 'error');
+        } finally {
+           if (eventSource && eventSource.readyState === EventSource.OPEN) {
+               sendToolCallBtn.disabled = false; // Re-enable button if SSE still open
+           }
+        }
+    }
+
+    connectBtn.addEventListener('click', connectSSE);
+    disconnectBtn.addEventListener('click', disconnectSSE);
+    sendToolCallBtn.addEventListener('click', sendToolCall);
+
+    // Optional: Auto-connect on load
+    // connectSSE();
+
+</script>
+
+</body>
+</html> 

--- a/openweather-mcp-server/package.json
+++ b/openweather-mcp-server/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "nandamcpserver",
+  "version": "1.0.0",
+  "description": "This project implements a Model Context Protocol (MCP) server using TypeScript, providing tools to fetch weather information and geocoding data via public APIs. It also includes an optional client for testing and outlines deployment steps for AWS App Runner.",
+  "main": "dist/server.js",
+  "scripts": {
+    "start": "node dist/server.js",
+    "build": "tsc",
+    "dev": "ts-node src/server.ts",
+    "test:client": "ts-node src/client.ts",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/node": "^22.5.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.4"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.8.0",
+    "@types/cors": "^2.8.17",
+    "@types/express": "^5.0.1",
+    "@types/ws": "^8.18.1",
+    "axios": "^1.7.4",
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^5.1.0",
+    "ws": "^8.18.1",
+    "zod": "^3.24.1"
+  }
+}

--- a/openweather-mcp-server/src/client.ts
+++ b/openweather-mcp-server/src/client.ts
@@ -1,0 +1,77 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+// import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"; // Use SSE instead
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js"; // Import SSE Client Transport
+import * as process from 'process';
+
+// Basic client implementation to test the SSE server
+
+async function runClient() {
+  console.log("Starting MCP client test (SSE against deployed service)...");
+
+  // Point to the deployed App Runner URL
+  const serverBaseUrl = `https://z3neqkdrhv.us-east-1.awsapprunner.com`;
+  const sseUrl = `${serverBaseUrl}/sse`;
+  // const messageUrl = `${serverBaseUrl}/messages`; // messageUrl is discovered from server event
+
+  const transport = new SSEClientTransport(new URL(sseUrl));
+
+  const client = new Client(
+    {
+      name: "ts-sse-client",
+      version: "0.1.0"
+    },
+    {
+      capabilities: {}
+    }
+  );
+
+  try {
+    // Connect to the server via SSE
+    console.log(`Connecting client to server via SSE at ${serverBaseUrl}...`);
+    await client.connect(transport);
+    console.log("Client connected.");
+
+    // Initialization is implicit with connect/first request in SSE transport
+
+    // List tools
+    console.log("\nListing available tools...");
+    const toolsList = await client.listTools();
+    console.log("Server Capabilities:", JSON.stringify(client.getServerCapabilities() ?? {}, null, 2));
+    console.log("Tools available:", JSON.stringify(toolsList.tools, null, 2));
+
+    // Call Weather tool
+    console.log("\nCalling get_current_weather...");
+    const weatherArgs = { location: "Tokyo, Japan", units: "metric" as const };
+    const weatherResult = await client.callTool({ name: "get_current_weather", arguments: weatherArgs });
+    console.log("Weather Result:", JSON.stringify(weatherResult, null, 2));
+    const weatherResultAny = weatherResult as any;
+    if(weatherResultAny.content?.[0]?.type === 'text') {
+        try {
+            console.log("Parsed Weather Content:", JSON.parse(weatherResultAny.content[0].text));
+        } catch { /* Ignore parse error if not JSON */ }
+    }
+
+    // Call Geocoding tool
+    console.log("\nCalling find_location_info...");
+    const geoArgs = { query: "Statue of Liberty" };
+    const geoResult = await client.callTool({ name: "find_location_info", arguments: geoArgs });
+    console.log("Geocoding Result:", JSON.stringify(geoResult, null, 2));
+    const geoResultAny = geoResult as any;
+    if(geoResultAny.content?.[0]?.type === 'text') {
+        try {
+            console.log("Parsed Geocoding Content:", JSON.parse(geoResultAny.content[0].text));
+        } catch { /* Ignore parse error if not JSON */ }
+    }
+
+
+  } catch (error) {
+    console.error("\nClient encountered an error:", error);
+  } finally {
+    // Close the connection
+    console.log("\nClosing client connection...");
+    await client.close();
+    console.log("Client finished.");
+  }
+}
+
+runClient(); 

--- a/openweather-mcp-server/src/server.ts
+++ b/openweather-mcp-server/src/server.ts
@@ -1,0 +1,167 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js"; // Import SSE transport
+// import { Transport } from "@modelcontextprotocol/sdk/transport.js"; // REMOVED Bad import
+import express, { Request, Response } from "express"; // Import Express
+import { z } from "zod";
+import axios from "axios";
+import * as dotenv from "dotenv";
+import * as path from 'path';
+import * as process from 'process';
+import { randomUUID } from 'crypto'; // For session IDs
+import cors from 'cors'; // Import cors
+
+// Configure dotenv
+dotenv.config({ path: path.resolve(process.cwd(), '.env') });
+
+console.log("Initializing MCP server logic...");
+
+const OPENWEATHERMAP_API_KEY = process.env.OPENWEATHERMAP_API_KEY;
+const PORT = process.env.PORT || 8000;
+
+// Create MCP server logic instance
+const mcpLogic = new McpServer({
+  name: "ts-multi-tool-server",
+  version: "0.1.0",
+  description: "Provides weather and geocoding tools via public APIs",
+});
+
+// --- Tool Definitions (Keep as before) --- //
+const weatherRawShape = {
+  location: z.string().describe("The city and state/country, e.g., \"San Francisco, CA\" or \"London, UK\""),
+  units: z.enum(["metric", "imperial", "standard"]).optional().default("metric").describe("Units for temperature (metric=Celsius, imperial=Fahrenheit, standard=Kelvin). Defaults to metric."),
+};
+const weatherSchema = z.object(weatherRawShape);
+type WeatherParams = z.infer<typeof weatherSchema>;
+mcpLogic.tool(
+  "get_current_weather",
+  weatherRawShape,
+  async (params: WeatherParams): Promise<{ content: { type: "text", text: string }[] }> => {
+    console.log(`Executing get_current_weather with params:`, params);
+    const { location, units } = params;
+    if (!OPENWEATHERMAP_API_KEY) throw new Error("Server configuration error: Weather API key missing.");
+    const apiUrl = "http://api.openweathermap.org/data/2.5/weather";
+    const apiParams = { q: location, appid: OPENWEATHERMAP_API_KEY, units: units };
+    try {
+      const response = await axios.get(apiUrl, { params: apiParams });
+      const data = response.data;
+      if (data.cod != 200) throw new Error(`Weather API error: ${data.message || "Unknown error"}`);
+      const mainWeather = data.weather?.[0] || {};
+      const mainTemp = data.main || {};
+      const result = { location_found: data.name, description: mainWeather.description, temperature: mainTemp.temp, feels_like: mainTemp.feels_like, humidity_percent: mainTemp.humidity, wind_speed: data.wind?.speed, units: units };
+      console.log(`Successfully fetched weather for '${location}'`);
+      return { content: [{ type: "text", text: JSON.stringify(result) }] };
+    } catch (error: any) { throw new Error(`Failed to get weather: ${error.message || error}`); }
+  }
+);
+const geocodingRawShape = {
+  query: z.string().describe("The place name or address to search for, e.g., \"Eiffel Tower\""),
+};
+const geocodingSchema = z.object(geocodingRawShape);
+type GeocodingParams = z.infer<typeof geocodingSchema>;
+mcpLogic.tool(
+  "find_location_info",
+  geocodingRawShape,
+  async (params: GeocodingParams): Promise<{ content: { type: "text", text: string }[] }> => {
+    console.log(`Executing find_location_info with params:`, params);
+    const { query } = params;
+    const apiUrl = "https://nominatim.openstreetmap.org/search";
+    const apiParams = { q: query, format: "json", limit: 1 };
+    const headers = { "User-Agent": "ts-mcp-server-demo/0.1 (Contact: your-email@example.com)" };
+    try {
+      const response = await axios.get(apiUrl, { params: apiParams, headers: headers });
+      const data = response.data;
+      if (!data || data.length === 0) throw new Error(`No results found for '${query}'`);
+      const topResult = data[0];
+      const result = { place_id: topResult.place_id, licence: topResult.licence, osm_type: topResult.osm_type, osm_id: topResult.osm_id, boundingbox: topResult.boundingbox, latitude: topResult.lat, longitude: topResult.lon, display_name: topResult.display_name, class: topResult.class, type: topResult.type, importance: topResult.importance };
+      console.log(`Successfully geocoded query: '${query}'`);
+      return { content: [{ type: "text", text: JSON.stringify(result) }] };
+    } catch (error: any) { throw new Error(`Failed during geocoding: ${error.message || error}`); }
+  }
+);
+
+// --- Express + SSE Server Setup --- //
+
+console.log("Setting up Express server...");
+const app = express();
+
+// Apply CORS middleware BEFORE routes
+app.use(cors({ origin: '*' })); // Allow all origins for simplicity, adjust for production
+
+const transports: { [sessionId: string]: SSEServerTransport } = {};
+
+// SSE endpoint for clients to connect
+app.get("/sse", async (req: Request, res: Response) => {
+  console.log("SSE connection requested");
+  try {
+    const sessionId = randomUUID();
+    console.log(`Creating SSE transport for sessionId: ${sessionId}`);
+    // Corrected SSEServerTransport constructor (removed sessionId)
+    const transport = new SSEServerTransport('/messages', res);
+    // The transport likely manages its own sessionId internally now.
+    // We need a way to retrieve it to store in our map.
+    // Assuming transport.sessionId exists after instantiation:
+    const transportSessionId = transport.sessionId; // Get session ID from transport
+    transports[transportSessionId] = transport;
+    console.log(`Transport stored with actual sessionId: ${transportSessionId}`);
+
+    req.on("close", () => {
+      console.log(`SSE connection closed for sessionId: ${transportSessionId}`);
+      delete transports[transportSessionId];
+      // transport.close(); // Transport might autoclose on req close
+    });
+
+    await mcpLogic.connect(transport);
+    console.log(`mcpLogic connected to transport for sessionId: ${transportSessionId}`);
+
+  } catch (error) {
+    console.error("Error setting up SSE connection:", error);
+    if (!res.headersSent) {
+        res.status(500).send('Failed to establish SSE connection');
+    }
+  }
+});
+
+// Endpoint for clients to send messages to the server
+app.post("/messages", async (req: Request, res: Response): Promise<void> => {
+  // Session ID should be provided by the transport/client, often in URL
+  const sessionId = req.query.sessionId as string;
+  console.log(`Received POST message for sessionId: ${sessionId}`);
+  console.log(`Current known transport sessionIds: ${Object.keys(transports).join(', ')}`);
+
+  if (!sessionId) {
+    res.status(400).send('Missing sessionId query parameter');
+    return;
+  }
+
+  const transport = transports[sessionId];
+  if (transport) {
+    try {
+      // Corrected handlePostMessage arguments: pass req and res
+      await transport.handlePostMessage(req, res);
+      // Transport handles the response, so we don't send one here
+    } catch (error) {
+      console.error(`Error handling POST message for sessionId ${sessionId}:`, error);
+      // Avoid sending response if transport already did or headers sent
+      if (!res.headersSent) {
+          res.status(500).send('Error processing message');
+      }
+      // No return here, error is handled
+    }
+  } else {
+    console.warn(`No active transport found for sessionId: ${sessionId}`);
+    res.status(404).send('No active session found for sessionId');
+    // No return here
+  }
+});
+
+// Health check endpoint
+app.get("/health", (req: Request, res: Response) => {
+  res.status(200).send("OK");
+});
+
+// Start the Express server
+app.listen(PORT, () => {
+  console.log(`MCP Server with Express listening on http://localhost:${PORT}`);
+  console.log(`SSE endpoint: http://localhost:${PORT}/sse`);
+  console.log(`Message endpoint: http://localhost:${PORT}/messages`);
+});

--- a/openweather-mcp-server/tsconfig.json
+++ b/openweather-mcp-server/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",                       // Target modern ECMAScript features
+    "module": "CommonJS",                     // Use CommonJS modules (standard for Node.js)
+    "outDir": "./dist",                        // Output directory for compiled JavaScript
+    "rootDir": "./src",                        // Root directory of source files
+    "strict": true,                         // Enable all strict type-checking options
+    "esModuleInterop": true,                  // Enables emit interoperability between CommonJS and ES Modules
+    "skipLibCheck": true,                   // Skip type checking of declaration files
+    "forceConsistentCasingInFileNames": true, // Disallow inconsistently-cased references to the same file.
+    "resolveJsonModule": true,                // Allow importing JSON files
+    "moduleResolution": "node"                // Use Node.js style module resolution
+  },
+  "include": ["src/**/*"],                    // Include all files in the src directory
+  "exclude": ["node_modules", "**/*.spec.ts"] // Exclude node_modules and test files
+} 


### PR DESCRIPTION
    This PR adds a new example MCP server implementation using TypeScript.

    - Server located in: `ts-mcp-server-weather-geo/`
    - Provides tools: `get_current_weather` (OpenWeatherMap) and `find_location_info` (OpenStreetMap Nominatim).
    - Uses Express and SSE for transport.
    - Includes Dockerfile for containerization and deployment instructions in the README.
    - Adds a simple index.html for browser-based testing.

    See the [README](ts-mcp-server-weather-geo/README.md) within the subdirectory for details on running and testing locally.